### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function win(options = {}) {
 				pid,
 				cmd: l.commandline,
 				ppid: Number.parseInt(l.parentprocessid, 10),
-				cpu: perfproc.find(record => Number.parseInt(record.idprocess) === pid).percentprocessortime/os.cpus().length,
+				cpu: perfproc.find(record => Number.parseInt(record.idprocess) === pid)?.percentprocessortime/os.cpus().length,
 				memory: Number.parseFloat(l.workingsetsize),
 				platform: process.platform
 			});


### PR DESCRIPTION
some systems/ such as mine,  (win10)
perfproc.find(record => Number.parseInt(record.idprocess) === pid) might be null, so .percentprocessortime  causes an error.
the ?  makes sure that even if its undefined it does not error due to that.

Error log:
```
TypeError: Cannot read property 'percentprocessortime' of undefined
    at C:\projects\someproject\node_modules\@667\ps-list\index.js:31:76
    at Array.map (<anonymous>)
    at win (C:\projects\someproject\node_modules\@667\ps-list\index.js:25:132)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

please consider my pull or make your own fix.

Thank you